### PR TITLE
Pre-Release Hotifxes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -217,20 +217,20 @@ dependencies {
     implementation(fg.deobf(group = "net.industrial-craft", name = "industrialcraft-2", version = "$versionIC2-ex112"))
     api(fg.deobf(group = "net.industrial-craft", name = "industrialcraft-2", version = "$versionIC2-ex112", classifier = "api")) //GTE api depends on the ic2 api
     
-    compileOnly(fg.deobf(group = "cofh", name = "RedstoneFlux", version = "1.12-$versionRF", classifier = "universal"))
-    compileOnly(fg.deobf(group = "cofh", name = "CoFHCore", version = "1.12.2-$versionCoFHCore", classifier = "universal")) {
+    implementation(fg.deobf(group = "cofh", name = "RedstoneFlux", version = "1.12-$versionRF", classifier = "universal"))
+    implementation(fg.deobf(group = "cofh", name = "CoFHCore", version = "1.12.2-$versionCoFHCore", classifier = "universal")) {
         exclude(group = "mezz.jei")
     }
-    compileOnly(fg.deobf(group = "cofh", name = "CoFHWorld", version = "1.12.2-$versionCoFHWorld", classifier = "universal"))
-    compileOnly(fg.deobf(group = "cofh", name = "ThermalFoundation", version = "1.12.2-$versionThermalFoundation", classifier = "universal"))
+    implementation(fg.deobf(group = "cofh", name = "CoFHWorld", version = "1.12.2-$versionCoFHWorld", classifier = "universal"))
+    implementation(fg.deobf(group = "cofh", name = "ThermalFoundation", version = "1.12.2-$versionThermalFoundation", classifier = "universal"))
     implementation(fg.deobf(group = "codechicken", name = "CodeChickenLib", version = "1.12.2-$versionCodeChickenLib", classifier = "universal"))
-    compileOnly(fg.deobf(group = "cofh", name = "ThermalExpansion", version = "1.12.2-$versionThermalExpansion", classifier = "universal")) { 
+    implementation(fg.deobf(group = "cofh", name = "ThermalExpansion", version = "1.12.2-$versionThermalExpansion", classifier = "universal")) { 
         exclude(group = "mezz.jei")
     }
     runtimeOnly(fg.deobf(group = "mezz.jei", name = "jei_$versionMc", version = versionJEI))
     compileOnly(group = "mezz.jei", name = "jei_$versionMc", version = versionJEI, classifier = "api")
     compileOnly(fg.deobf(group = "com.mod-buildcraft", name = "buildcraft-main", version = versionBuildCraft))
-    compileOnly(fg.deobf(curse(mod = "energy-control", projectId = 51195, fileId = versionEnergyControl.toLong())))
+    implementation(fg.deobf(curse(mod = "energy-control", projectId = 51195, fileId = versionEnergyControl.toLong())))
     compileOnly(fg.deobf(curse(mod = "railcraft", projectId = 51195, fileId = versionRailcraft.toLong())))
     compileOnly(fg.deobf(curse(mod = "applied-energistics-2", projectId = 223794, fileId = versionAE2.toLong())))
     compileOnly(fg.deobf(curse(mod = "thaumcraft", projectId = 223628, fileId = versionThaumcraft.toLong())))
@@ -272,8 +272,8 @@ publishing {
 
 fun getGitVersion(): String {
     val jgitver = GitVersionCalculator.location(rootDir)
-            .setNonQualifierBranches("forge-1.12.2")
-            .setVersionPattern("\${M}\${<m}\${<meta.COMMIT_DISTANCE}\${-~meta.QUALIFIED_BRANCH_NAME}")
-            .setStrategy(Strategies.PATTERN)
+        .setNonQualifierBranches("forge-1.12.2")
+        .setStrategy(Strategies.SCRIPT)
+        .setScript("print \"\${metadata.CURRENT_VERSION_MAJOR};\${metadata.CURRENT_VERSION_MINOR};\${metadata.CURRENT_VERSION_PATCH + metadata.COMMIT_DISTANCE}\"")
     return jgitver.version
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -217,20 +217,20 @@ dependencies {
     implementation(fg.deobf(group = "net.industrial-craft", name = "industrialcraft-2", version = "$versionIC2-ex112"))
     api(fg.deobf(group = "net.industrial-craft", name = "industrialcraft-2", version = "$versionIC2-ex112", classifier = "api")) //GTE api depends on the ic2 api
     
-    implementation(fg.deobf(group = "cofh", name = "RedstoneFlux", version = "1.12-$versionRF", classifier = "universal"))
-    implementation(fg.deobf(group = "cofh", name = "CoFHCore", version = "1.12.2-$versionCoFHCore", classifier = "universal")) {
+    compileOnly(fg.deobf(group = "cofh", name = "RedstoneFlux", version = "1.12-$versionRF", classifier = "universal"))
+    compileOnly(fg.deobf(group = "cofh", name = "CoFHCore", version = "1.12.2-$versionCoFHCore", classifier = "universal")) {
         exclude(group = "mezz.jei")
     }
-    implementation(fg.deobf(group = "cofh", name = "CoFHWorld", version = "1.12.2-$versionCoFHWorld", classifier = "universal"))
-    implementation(fg.deobf(group = "cofh", name = "ThermalFoundation", version = "1.12.2-$versionThermalFoundation", classifier = "universal"))
+    compileOnly(fg.deobf(group = "cofh", name = "CoFHWorld", version = "1.12.2-$versionCoFHWorld", classifier = "universal"))
+    compileOnly(fg.deobf(group = "cofh", name = "ThermalFoundation", version = "1.12.2-$versionThermalFoundation", classifier = "universal"))
     implementation(fg.deobf(group = "codechicken", name = "CodeChickenLib", version = "1.12.2-$versionCodeChickenLib", classifier = "universal"))
-    implementation(fg.deobf(group = "cofh", name = "ThermalExpansion", version = "1.12.2-$versionThermalExpansion", classifier = "universal")) { 
+    compileOnly(fg.deobf(group = "cofh", name = "ThermalExpansion", version = "1.12.2-$versionThermalExpansion", classifier = "universal")) { 
         exclude(group = "mezz.jei")
     }
     runtimeOnly(fg.deobf(group = "mezz.jei", name = "jei_$versionMc", version = versionJEI))
     compileOnly(group = "mezz.jei", name = "jei_$versionMc", version = versionJEI, classifier = "api")
     compileOnly(fg.deobf(group = "com.mod-buildcraft", name = "buildcraft-main", version = versionBuildCraft))
-    implementation(fg.deobf(curse(mod = "energy-control", projectId = 51195, fileId = versionEnergyControl.toLong())))
+    compileOnly(fg.deobf(curse(mod = "energy-control", projectId = 51195, fileId = versionEnergyControl.toLong())))
     compileOnly(fg.deobf(curse(mod = "railcraft", projectId = 51195, fileId = versionRailcraft.toLong())))
     compileOnly(fg.deobf(curse(mod = "applied-energistics-2", projectId = 223794, fileId = versionAE2.toLong())))
     compileOnly(fg.deobf(curse(mod = "thaumcraft", projectId = 223628, fileId = versionThaumcraft.toLong())))

--- a/src/main/java/mods/gregtechmod/core/GregTechMod.java
+++ b/src/main/java/mods/gregtechmod/core/GregTechMod.java
@@ -15,6 +15,7 @@ import mods.gregtechmod.objects.blocks.teblocks.component.*;
 import mods.gregtechmod.recipe.compat.ModRecipes;
 import mods.gregtechmod.recipe.crafting.AdvancementRecipeFixer;
 import mods.gregtechmod.recipe.util.DamagedOreIngredientFixer;
+import mods.gregtechmod.util.GtUtil;
 import mods.gregtechmod.util.IProxy;
 import mods.gregtechmod.util.LootFunctionWriteBook;
 import mods.gregtechmod.world.OreGenerator;
@@ -25,6 +26,8 @@ import net.minecraft.world.storage.loot.LootTableList;
 import net.minecraft.world.storage.loot.functions.LootFunctionManager;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.Mod.Instance;
@@ -128,12 +131,12 @@ public final class GregTechMod {
 
         MachineRecipeLoader.registerDynamicRecipes();
         DamagedOreIngredientFixer.fixRecipes();
-        AdvancementRecipeFixer.fixAdvancementRecipes();
+        GtUtil.withModContainerOverride(Loader.instance().getMinecraftModContainer(), AdvancementRecipeFixer::fixAdvancementRecipes);
     }
 
     @SubscribeEvent
     public void registerTEBlocks(TeBlockFinalCallEvent event) {
-        TeBlockRegistry.addAll(GregTechTEBlock.class, GregTechTEBlock.LOCATION);
+        GtUtil.withModContainerOverride(FMLCommonHandler.instance().findContainerFor(Reference.MODID), () -> TeBlockRegistry.addAll(GregTechTEBlock.class, GregTechTEBlock.LOCATION));
         TeBlockRegistry.addCreativeRegisterer(GregTechTEBlock.INDUSTRIAL_CENTRIFUGE, GregTechTEBlock.LOCATION);
     }
 

--- a/src/main/java/mods/gregtechmod/init/OreDictRegistrar.java
+++ b/src/main/java/mods/gregtechmod/init/OreDictRegistrar.java
@@ -36,7 +36,6 @@ public class OreDictRegistrar {
 
         Arrays.stream(BlockItems.Ingot.values())
                 .forEach(ingot -> registerOre("ingot", ingot.name().toLowerCase(Locale.ROOT), ingot.getInstance()));
-        registerOre("ingotAlloyIridium", BlockItems.Ingot.IRIDIUM_ALLOY.getInstance());
 
         Arrays.stream(BlockItems.Nugget.values())
                 .forEach(nugget -> registerOre("nugget", nugget.name().toLowerCase(Locale.ROOT), nugget.getInstance()));

--- a/src/main/java/mods/gregtechmod/recipe/RecipeSawmill.java
+++ b/src/main/java/mods/gregtechmod/recipe/RecipeSawmill.java
@@ -29,7 +29,7 @@ public class RecipeSawmill extends Recipe<List<IRecipeIngredient>, List<ItemStac
                                        @JsonProperty(value = "universal") boolean universal) {
         output = RecipeUtil.adjustOutputCount("sawmill", output, 2);
 
-        IRecipeIngredientFluid fluid = RecipeIngredientFluid.fromFluid(FluidRegistry.WATER, water);
+        IRecipeIngredientFluid fluid = RecipeIngredientFluid.fromFluid(FluidRegistry.WATER, Math.max(water, 1));
         RecipeSawmill recipe = new RecipeSawmill(input, fluid, output, universal);
 
         if (!RecipeUtil.validateRecipeIO("sawmill", input, output)) recipe.invalid = true;

--- a/src/main/java/mods/gregtechmod/recipe/crafting/AdvancementRecipeFixer.java
+++ b/src/main/java/mods/gregtechmod/recipe/crafting/AdvancementRecipeFixer.java
@@ -16,7 +16,7 @@ public class AdvancementRecipeFixer {
     
     public static void fixAdvancementRecipes() {
         GregTechMod.logger.info("Fixing Advancements");
-        
+       
         REPLACED_RECIPES
                 .forEach(recipe -> {
                     ResourceLocation output = recipe.getRecipeOutput().getItem().getRegistryName();

--- a/src/main/java/mods/gregtechmod/util/GtUtil.java
+++ b/src/main/java/mods/gregtechmod/util/GtUtil.java
@@ -43,6 +43,7 @@ import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidTankProperties;
 import net.minecraftforge.fluids.capability.templates.EmptyFluidHandler;
 import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.oredict.OreDictionary;
 
 import javax.annotation.Nullable;
@@ -393,6 +394,15 @@ public class GtUtil {
         } catch (NoSuchFieldException | IllegalAccessException e) {
             GregTechMod.logger.error(e);
         }
+    }
+    
+    public static void withModContainerOverride(ModContainer container, Runnable runnable) {
+        ModContainer old = Loader.instance().activeModContainer();
+        Loader.instance().setActiveModContainer(container);
+        
+        runnable.run();
+        
+        Loader.instance().setActiveModContainer(old);
     }
     
     private static class VoidTank implements IFluidHandler {


### PR DESCRIPTION
Changes:
- Added a default value for RecipeSawmill water count
- Removed "Dangerous Prefix" warnings from FML by overriding the active mod container
- Removed the Iridium Alloy Ingot from OreDict (needless recipes were generated by the OreDictHandler)
- Set the patch version to be a sum of the current patch version and the commit distance. This allow tagging patch versions, too.